### PR TITLE
Closes #9, mistaken test condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 .RData
 
 # RStudio files
-.Rproj.user/
+.Rproj.user
+*.Rproj
 
 # produced vignettes
 vignettes/*.html

--- a/R/microbenchmark.R
+++ b/R/microbenchmark.R
@@ -128,7 +128,7 @@ microbenchmark <- function(..., list=NULL,
                            setup=NULL) {
   stopifnot(times == as.integer(times))
   if (!missing(unit))
-    stopifnot(is.character("unit"), length(unit) == 1L)
+    stopifnot(is.character(unit), length(unit) == 1L)
 
   control[["warmup"]] <- coalesce(control[["warmup"]], 2^18L)
   control[["order"]] <- coalesce(control[["order"]], "random")

--- a/inst/tests/test_regression.R
+++ b/inst/tests/test_regression.R
@@ -16,6 +16,13 @@ test_unit_f <- function()
 }
 test_unit_f()
 
+test_unit_int <- function()
+{
+  out <- try(print(microbenchmark(NULL, unit=4)), silent = TRUE)
+  stopifnot(!inherits(out, "try-error"))
+}
+test_unit_int()
+
 test_simple_timing <- function()
 {
   set.seed(21)


### PR DESCRIPTION
`is.character('unit')` is trivially `TRUE` for all values of `unit` argument, i.e. this test was on the variable name, not the variable itself.

Very simple fix; more importantly, test added to be sure this type test is working as intended.

Bug fixed is #9.

The second commit tinkers with `.gitignore`.

 - `.Rproj` files are very small but don't really add much ([e.g.](https://github.com/MichaelChirico/top_hanzi/blob/master/top_hanzi.Rproj))
 - Having the trailing slash `/` on the `.RProj.user` folder was confusing RStudio for some reason. It kept trying to edit the `.gitignore` to add `.RProj.user` to the end... really an upstream bug but it doesn't hurt to make this fix.