### PR TITLE
Fail before running benchmark if factor is to fail

### DIFF
--- a/R/microbenchmark.R
+++ b/R/microbenchmark.R
@@ -190,6 +190,7 @@ microbenchmark <- function(..., list=NULL,
     stop("Unknown ordering. Must be one of 'random', 'inorder' or 'block'.")
   exprs <- exprs[o]
 
+  expr <- factor(nm[o], levels = nm)
   res <- .Call(do_microtiming, exprs, env,
                as.integer(control$warmup), setup,
                PACKAGE="microbenchmark")
@@ -199,7 +200,7 @@ microbenchmark <- function(..., list=NULL,
   if (all(is.na(res)))
     .all_na_stop()
 
-  res <- data.frame(expr = factor(nm[o], levels = nm), time=res)
+  res <- data.frame(expr = expr, time=res)
   class(res) <- c("microbenchmark", class(res))
   if (!is.null(unit))
     attr(res, "unit") <- unit


### PR DESCRIPTION
This proposes to fail before running the benchmark for cases like where `factor(nm[o], levels = nm)` is to fail. Notable use case is when user provides duplicated names by mistake, e.g.:

```
microbenchmark::microbenchmark(a=runif(1000000), a=1)
```