### PR TITLE
Fix issue #35: Make y_max work in autoplot

### DIFF
--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -23,21 +23,24 @@
 #' @author Ari Friedman, Olaf Mersmann
 autoplot.microbenchmark <- function(object, ...,
                                     log=TRUE,
-                                    y_max=1.05 * max(object$time)) {
+                                    y_max=NULL) {
   if (!requireNamespace("ggplot2"))
     stop("Missing package 'ggplot2'.")
   y_min <- 0
   object$ntime <- convert_to_unit(object$time, "t")
+  if (is.null(y_max)) {
+    y_max <- max(object$ntime)
+  }
   plt <- ggplot2::ggplot(object, ggplot2::aes_string(x="expr", y="ntime"))
-  plt <- plt + ggplot2::coord_cartesian(ylim=c(y_min , y_max))
   plt <- plt + ggplot2::stat_ydensity()
   plt <- plt + ggplot2::scale_x_discrete(name="")
   y_label <- sprintf("Time [%s]", attr(object$ntime, "unit"))
-  plt <- if (log) {
-    plt + ggplot2::scale_y_log10(name=y_label)
+  if (log) {
+    y_min <- min(object$ntime)
+    plt <- plt + ggplot2::scale_y_log10(name=y_label)
   } else {
-    plt + ggplot2::scale_y_continuous(name=y_label)
+    plt <- plt + ggplot2::scale_y_continuous(name=y_label)
   }
-  plt <- plt + ggplot2::coord_flip()
+  plt <- plt + ggplot2::coord_flip(ylim=c(y_min , y_max))
   plt
 }


### PR DESCRIPTION
The y_max parameter in autoplot.microbenchmark is currently ignored, because coord_flip cancels out the previous call to coord_cartesian. Also, coord_cartesian is redundant, as its ylim argument can be passed to coord_flip instead.

Now that y_max works, two issues appear in how it works: First, y_min cannot be 0 on a log axis, so I use the minimum value from object$ntime when log == TRUE. Second, the default value for y_max is derived from object$time, while the plot uses object$ntime, so I replaced the default with NULL and calculate the default value after calculating object$ntime. Note that the previous default for y_max also had no effect. This is why I did not keep the 1.05 factor, as it would change the behaviour compared to before.

Calling the function without y_max produces the same plots as before, but without the warning from coord_flip that it is replacing the coordinate system from coord_cartesian.

Fixes #35.