### PR TITLE
Make CLOCK_MONOTONIC_PRECISE reachable on FreeBSD

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -6,3 +6,8 @@ PKG_LIBS = @MB_LIBS@
 ## set.
 ##
 PKG_CPPFLAGS = -D_POSIX_C_SOURCE=200112L @DEFS@
+
+UNAME := $(shell uname)
+ifeq ($(UNAME), FreeBSD)
+PKG_CPPFLAGS += -D__BSD_VISIBLE=1
+endif


### PR DESCRIPTION
On FreeBSD, the build breaks with the following error: use of undeclared identifier 'CLOCK_MONOTONIC_PRECISE'. This happens, because CLOCK_MONOTONIC_PRECISE from time.h is not visible on FreeBSD, if _POSIX_C_SOURCE=200112L is defined (Issue #33). The patch makes it visible the hard way ;)

Please review the [contributing guide](CONTRIBUTING.md) before submitting your pull request. Please pay special attention to the [pull request](CONTRIBUTING.md#want-to-submit-a-pull-request) and [commit message](CONTRIBUTING.md#commit-messages) sections. Thanks for your contribution and interest in the project!
